### PR TITLE
fix: improve scrolling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -87,6 +87,7 @@ section {
     position: fixed;
     bottom: calc((var(--ring-diameter)*.7)*-1vw);
     left: 0;
+    pointer-events: none;
 }
 
 /* these are the spinning elements */
@@ -100,6 +101,7 @@ section {
     transform: rotate(-30deg);
     -webkit-animation: spin-right 100s linear infinite;
     animation: spin-right 100s linear infinite;
+    pointer-events: auto;
 }
 
 .spin .listing {


### PR DESCRIPTION
This PR improves the site's scrolling behavior by disabling pointer events on the spinner bg. 

Previously, scrolling only worked when your mouse was carefully positioned above the spinner's background gradient. On mobile, this also reduced the surface area for scrolling. 

Now, you can scroll naturally, without regard for where your cursor is. Pointer-events: auto is set on the rings themselves, to preserve native highlighting and clicking of links in the spinner. 